### PR TITLE
Fixing the concerns of the `Deferred` & changing the constructor to a factory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "0.10"
+  - "0.12"
+  - "iojs"

--- a/deferred.js
+++ b/deferred.js
@@ -2,14 +2,15 @@
 
 var Promise = global.Promise || require('es6-promise').Promise;
 
-var Deferred = function() {
-  this.promise = new Promise((function(resolve, reject) {
-    this.resolve = resolve;
-    this.reject = reject;
-  }).bind(this));
-  
-  this.then = this.promise.then.bind(this.promise);
-  this.catch = this.promise.catch.bind(this.promise);
-};
+function deferred () {
+  var promise, resolver, rejecter;
 
-module.exports = Deferred;
+  promise = new Promise(function (resolve, reject) {
+    resolver = resolve;
+    rejecter = reject;
+  });
+
+  return {resolve: resolver, reject: rejecter, promise: promise};
+}
+
+module.exports = deferred;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es6-deferred",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "Deferred the ES6 way",
   "main": "deferred.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 ## Usage
 
 ````javascript
-var Deferred = require('es6-deferred');
-var d = new Deferred();
+var deferred = require('es6-deferred');
+var d = deferred();
 ````
 
 ### `d.promise`

--- a/readme.md
+++ b/readme.md
@@ -17,14 +17,6 @@ Resolves the promise with the given value.
 
 Rejects the promise with the given error.
 
-### `d.then(onFulfilled, onRejected)`
-
-Appends a fulfillment and rejection handler to the promise.
-
-### `d.catch(onRejected)`
-
-Appends a rejection handler to the promise.
-
 ## License
 
 MIT

--- a/test.js
+++ b/test.js
@@ -53,7 +53,7 @@ describe('Deferred', function() {
       this.timeout(200);
       var d = new Deferred();
       d.resolve(1);
-      d.then(function (n) {
+      d.promise.then(function (n) {
         expect(n).to.equal(1);
         cb();
       });
@@ -63,7 +63,7 @@ describe('Deferred', function() {
       this.timeout(200);
       var d = new Deferred();
       d.reject(2);
-      d.catch(function (n) {
+      d.promise.catch(function (n) {
         expect(n).to.equal(2);
         cb();
       });


### PR DESCRIPTION
- [x] Changes constructor to factory
- [x] Refactors `Deferred` based on Single Responsibility Principle; the purpose is to resolve/reject from the "outside"
- [x] Removed `catch()` & `then()` which were inconsistent decorations of the `Promise` API on the wrapping `Deferred` (you had left off `all()`)
- [x] Updated README

I find myself re-creating this function for a few of my base projects, so I'd prefer to fix your lib instead of making one that's practically the same.
